### PR TITLE
Enable build caching

### DIFF
--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -19,10 +19,10 @@
   </buildScan>
   <buildCache>
     <local>
-      <enabled>false</enabled>
+      <enabled>#{isFalse(env['CI']) and isFalse(env['JENKINS_URL'])}</enabled>
     </local>
     <remote>
-      <enabled>false</enabled>
+      <enabled>#{isTrue(env['CI']) or isTrue(env['JENKINS_URL'])}</enabled>
       <storeEnabled>#{isTrue(env['CI']) or isTrue(env['JENKINS_URL'])}</storeEnabled>
     </remote>
   </buildCache>


### PR DESCRIPTION
This PR enables [build caching](https://docs.gradle.com/develocity/maven-build-cache/), which will improve both local and CI build times. For local builds it enables only the local cache, and for CI builds it enables only the remote cache, as proposed in the [Eclipse Develocity documentation](https://gitlab.eclipse.org/eclipsefdn/it/releng/develocity/develocity-documentation#mvndevelocityxml).

After running some tests, when cache is enabled, as the average build is 28% quicker for consecutive builds than no Develocity extension -> [2:31](https://github.com/ribafish/eclipse-glassfish/actions/runs/12912080808/attempts/1#summary-36006040083) min vs [2:08 min](https://github.com/ribafish/eclipse-glassfish/actions/runs/12912080808/attempts/1#summary-36006038437). 

This speedup is even more visible when tests are executed (running `mvn clean install`), as the build is already ~56% quicker, without any further caching optimisations. [Without the cache](https://github.com/ribafish/eclipse-glassfish/actions/runs/12912080808/attempts/1#summary-36006040694), average build takes [27:45 min](https://github.com/ribafish/eclipse-glassfish/actions/runs/12912080808/attempts/1#summary-36006040694) (ignoring the ~14sec ones, which are failed) without the cache, while [average with the cache](https://github.com/ribafish/eclipse-glassfish/actions/runs/12912080808/attempts/1#summary-36006039413) takes 14min with the seeding build, with consecutive builds taking on average just [12:18 min](https://github.com/ribafish/eclipse-glassfish/actions/runs/12912080808/attempts/1#summary-36006039413).

This PR relates to issue https://github.com/eclipse-ee4j/glassfish/issues/25322 and includes the changes from PR https://github.com/eclipse-ee4j/glassfish/pull/25342.